### PR TITLE
feat: add search button to main tabs bar

### DIFF
--- a/TMessagesProj/src/main/java/org/telegram/ui/ContactsActivity.java
+++ b/TMessagesProj/src/main/java/org/telegram/ui/ContactsActivity.java
@@ -1730,4 +1730,18 @@ public class ContactsActivity extends BaseFragment implements FactorAnimator.Tar
 //        animatorSearchFieldHeight.animateTo(dp(DialogsActivity.SEARCH_FIELD_HEIGHT));
         animatorSearchFieldVisible.setValue(true, true);
     }
+
+    @Override
+    public void onSearchButtonClicked() {
+        listView.smoothScrollToPosition(0);
+        AndroidUtilities.doOnPreDraw(searchField.editText, () -> {
+            searchField.editText.requestFocus();
+            AndroidUtilities.showKeyboard(searchField.editText);
+        });
+    }
+
+    @Override
+    public boolean hasSearch() {
+        return true;
+    }
 }

--- a/TMessagesProj/src/main/java/org/telegram/ui/DialogsActivity.java
+++ b/TMessagesProj/src/main/java/org/telegram/ui/DialogsActivity.java
@@ -5872,8 +5872,12 @@ public class DialogsActivity extends BaseFragment implements NotificationCenter.
         }
     }
 
+    private boolean shouldReplaceHomeSearchFieldWithMainTabsButton() {
+        return hasMainTabs && NaConfig.INSTANCE.getMainTabsShowSearchButton().Bool();
+    }
+
     private boolean shouldHideHomeSearchField() {
-        return NaConfig.INSTANCE.getHideHomeSearchField().Bool()
+        return (NaConfig.INSTANCE.getHideHomeSearchField().Bool() || shouldReplaceHomeSearchFieldWithMainTabsButton())
                 && initialDialogsType == DIALOGS_TYPE_DEFAULT
                 && !onlySelect
                 && folderId == 0
@@ -14134,7 +14138,7 @@ public class DialogsActivity extends BaseFragment implements NotificationCenter.
         final float factor1 = animatorSearchButtonVisible.getFloatValue();
         final float factor2 = 1f - getRightSlidingProgress();
         final float factor3 = 1f - animatorDoneButtonVisible.getFloatValue();
-        final float factor = factor0 * factor1 * factor2 * factor3;
+        final float factor = shouldHideHomeSearchField() ? 0 : factor0 * factor1 * factor2 * factor3;
         FragmentFloatingButton.setAnimatedVisibility(searchItem, factor);
         if (dialogStoriesCell != null) {
             dialogStoriesCell.invalidate();
@@ -14261,6 +14265,23 @@ public class DialogsActivity extends BaseFragment implements NotificationCenter.
     @Override
     public void onParentScrollToTop() {
         scrollToTop(true, true);
+    }
+
+    @Override
+    public void onSearchButtonClicked() {
+        showSearch(true, false, true);
+        fragmentSearchFieldWatcher.toggleSearch(true);
+        AndroidUtilities.runOnUIThread(() -> {
+            if (fragmentSearchField != null && fragmentSearchField.editText != null) {
+                fragmentSearchField.editText.requestFocus();
+                AndroidUtilities.showKeyboard(fragmentSearchField.editText);
+            }
+        }, 100);
+    }
+
+    @Override
+    public boolean hasSearch() {
+        return true;
     }
 
     private void switchTheme(Theme.ThemeInfo themeInfo, boolean toDark) {

--- a/TMessagesProj/src/main/java/org/telegram/ui/MainTabsActivity.java
+++ b/TMessagesProj/src/main/java/org/telegram/ui/MainTabsActivity.java
@@ -10,6 +10,8 @@ import android.content.Context;
 import android.content.Intent;
 import android.graphics.Canvas;
 import android.graphics.Paint;
+import android.graphics.PorterDuff;
+import android.graphics.PorterDuffColorFilter;
 import android.graphics.RectF;
 import android.graphics.drawable.ShapeDrawable;
 import android.os.Build;
@@ -21,6 +23,7 @@ import android.view.MotionEvent;
 import android.view.View;
 import android.view.ViewGroup;
 import android.widget.FrameLayout;
+import android.widget.ImageView;
 import android.widget.LinearLayout;
 import android.widget.TextView;
 
@@ -102,9 +105,12 @@ public class MainTabsActivity extends ViewPagerActivity implements NotificationC
 
     private UpdateLayoutWrapper updateLayoutWrapper;
     private FrameLayout tabsViewWrapper;
+    private LinearLayout tabsBarContainer;
     private MainTabsLayout tabsView;
     private BlurredBackgroundDrawable tabsViewBackground;
+    private BlurredBackgroundDrawable searchTabButtonBackground;
     private View fadeView;
+    private FrameLayout searchTabButton;
     private ArrayList<MainTabsConfigManager.TabState> configuredTabs = new ArrayList<>();
     private boolean lastBottomBarHidden = isBottomBarHidden();
 
@@ -287,11 +293,56 @@ public class MainTabsActivity extends ViewPagerActivity implements NotificationC
         fadeView.setBackground(fadeDrawable);
 
         contentView.addView(fadeView, LayoutHelper.createFrame(LayoutHelper.MATCH_PARENT, 0, Gravity.BOTTOM));
-
         tabsViewWrapper = new FrameLayout(context);
         tabsViewWrapper.setOnClickListener(v -> {});
-        tabsViewWrapper.addView(tabsView, LayoutHelper.createFrame(328 + DialogsActivity.MAIN_TABS_MARGIN * 2, DialogsActivity.MAIN_TABS_HEIGHT_WITH_MARGINS, Gravity.BOTTOM | Gravity.CENTER_HORIZONTAL));
+        tabsViewWrapper.setClipChildren(false);
         tabsViewWrapper.setClipToPadding(false);
+
+        tabsBarContainer = new LinearLayout(context);
+        tabsBarContainer.setOrientation(LinearLayout.HORIZONTAL);
+        tabsBarContainer.setGravity(Gravity.CENTER_VERTICAL | Gravity.CENTER_HORIZONTAL);
+        tabsBarContainer.setClipChildren(false);
+        tabsBarContainer.setClipToPadding(false);
+        tabsBarContainer.setPadding(dp(2), 0, dp(2), 0);
+        tabsView.setTranslationX(0f);
+        tabsBarContainer.addView(tabsView, LayoutHelper.createLinear(dp(MainTabsHelper.getTabsViewWidth()), DialogsActivity.MAIN_TABS_HEIGHT_WITH_MARGINS));
+
+        searchTabButton = new FrameLayout(context);
+        searchTabButton.setClipChildren(false);
+        searchTabButton.setClipToPadding(false);
+        searchTabButtonBackground = iBlur3FactoryGlass.create(searchTabButton, BlurredBackgroundProviderImpl.mainTabs(resourceProvider));
+        searchTabButtonBackground.setRadius(dp(28));
+        searchTabButtonBackground.setPadding(dp(0.334f));
+        searchTabButton.setBackground(searchTabButtonBackground);
+
+        ImageView searchIcon = new ImageView(context);
+        searchIcon.setImageResource(R.drawable.outline_header_search);
+        searchIcon.setPadding(dp(14), dp(14), dp(14), dp(14));
+        searchIcon.setColorFilter(new PorterDuffColorFilter(
+            Theme.getColor(Theme.key_glass_tabUnselected, resourceProvider), PorterDuff.Mode.SRC_IN));
+        searchTabButton.addView(searchIcon, LayoutHelper.createFrame(LayoutHelper.MATCH_PARENT, LayoutHelper.MATCH_PARENT));
+
+        searchTabButton.setClickable(true);
+        searchTabButton.setContentDescription(getString(R.string.Search));
+        searchTabButton.setOnClickListener(v -> onSearchTabButtonClicked());
+        searchTabButton.setOnLongClickListener(v -> {
+            onSearchTabButtonLongClicked();
+            return true;
+        });
+        int searchBtnSize = dp(56);
+        LinearLayout.LayoutParams searchBtnLp = new LinearLayout.LayoutParams(searchBtnSize, searchBtnSize);
+        searchBtnLp.setMarginStart(-dp(10));
+        searchBtnLp.setMarginEnd(dp(4));
+        tabsBarContainer.addView(searchTabButton, searchBtnLp);
+        tabsViewWrapper.addView(tabsBarContainer, LayoutHelper.createFrame(LayoutHelper.WRAP_CONTENT, DialogsActivity.MAIN_TABS_HEIGHT_WITH_MARGINS, Gravity.BOTTOM | Gravity.CENTER_HORIZONTAL));
+
+        tabsViewWrapper.addOnLayoutChangeListener(new View.OnLayoutChangeListener() {
+            @Override
+            public void onLayoutChange(View v, int left, int top, int right, int bottom, int oldLeft, int oldTop, int oldRight, int oldBottom) {
+                repositionSearchButton();
+            }
+        });
+
         contentView.addView(tabsViewWrapper, LayoutHelper.createFrame(LayoutHelper.MATCH_PARENT, LayoutHelper.WRAP_CONTENT, Gravity.BOTTOM));
 
         updateLayoutWrapper = new UpdateLayoutWrapper(context);
@@ -303,6 +354,7 @@ public class MainTabsActivity extends ViewPagerActivity implements NotificationC
         }
 
         checkUnreadCount(false);
+        updateSearchTabButtonVisibility();
         return contentView;
     }
 
@@ -768,6 +820,7 @@ public class MainTabsActivity extends ViewPagerActivity implements NotificationC
             checkUi_fadeView();
         }
         checkContactsTabBadge();
+        updateSearchTabButtonVisibility();
     }
 
 
@@ -784,6 +837,14 @@ public class MainTabsActivity extends ViewPagerActivity implements NotificationC
 
         default BlurredBackgroundSourceRenderNode getGlassSource() {
             return null;
+        }
+
+        default void onSearchButtonClicked() {
+
+        }
+
+        default boolean hasSearch() {
+            return false;
         }
     }
 
@@ -985,6 +1046,9 @@ public class MainTabsActivity extends ViewPagerActivity implements NotificationC
             tabsView.setEnabled(false);
             tabsView.setAlpha(0f);
             tabsView.setVisibility(View.GONE);
+            if (searchTabButton != null) {
+                searchTabButton.setVisibility(View.GONE);
+            }
             return;
         }
         final boolean isUpdateLayoutVisible = updateLayoutWrapper.isUpdateLayoutVisible();
@@ -1140,6 +1204,9 @@ public class MainTabsActivity extends ViewPagerActivity implements NotificationC
         if (tabsViewBackground != null) {
             tabsViewBackground.updateColors();
         }
+        if (searchTabButtonBackground != null) {
+            searchTabButtonBackground.updateColors();
+        }
         blur3_invalidateBlur();
         if (fadeView != null) {
             fadeView.invalidate();
@@ -1147,6 +1214,10 @@ public class MainTabsActivity extends ViewPagerActivity implements NotificationC
         if (tabsView != null) {
             tabsView.invalidate();
         }
+        if (searchTabButton != null) {
+            searchTabButton.invalidate();
+        }
+        updateSearchTabButtonVisibility();
         if (tabs != null) {
             for (GlassTabView tabView : tabs) {
                 tabView.updateColorsLottie();
@@ -1214,7 +1285,6 @@ public class MainTabsActivity extends ViewPagerActivity implements NotificationC
         o.show();
         return true;
     }
-
     private void setupPopupMenuStyle(ItemOptions options) {
         options.setBlur(true);
         options.translate(0, -dp(4));
@@ -1222,5 +1292,114 @@ public class MainTabsActivity extends ViewPagerActivity implements NotificationC
         bg.getPaint().setShadowLayer(dp(6), 0, dp(1), Theme.multAlpha(0xFF000000, 0.15f));
         options.setScrimViewBackground(bg);
     }
+    private void repositionSearchButton() {
+        if (searchTabButton == null || tabsView == null || tabsViewWrapper == null || tabsBarContainer == null) return;
+        boolean show = NaConfig.INSTANCE.getMainTabsShowSearchButton().Bool() && !isBottomBarHidden();
+
+        ViewGroup.LayoutParams tabsBaseLp = tabsView.getLayoutParams();
+        LinearLayout.LayoutParams tabsLp;
+        if (tabsBaseLp instanceof LinearLayout.LayoutParams) {
+            tabsLp = (LinearLayout.LayoutParams) tabsBaseLp;
+        } else {
+            tabsLp = new LinearLayout.LayoutParams(dp(MainTabsHelper.getTabsViewWidth()), dp(DialogsActivity.MAIN_TABS_HEIGHT_WITH_MARGINS));
+            tabsView.setLayoutParams(tabsLp);
+        }
+
+        ViewGroup.LayoutParams searchBaseLp = searchTabButton.getLayoutParams();
+        LinearLayout.LayoutParams searchLp;
+        if (searchBaseLp instanceof LinearLayout.LayoutParams) {
+            searchLp = (LinearLayout.LayoutParams) searchBaseLp;
+        } else {
+            int searchBtnSize = dp(56);
+            searchLp = new LinearLayout.LayoutParams(searchBtnSize, searchBtnSize);
+            searchLp.setMarginStart(-dp(10));
+            searchTabButton.setLayoutParams(searchLp);
+        }
+
+        tabsView.setTranslationX(0f);
+        searchTabButton.setTranslationX(0f);
+        tabsBarContainer.setTranslationX(0f);
+
+        if (!show) {
+            int baseTabsWidth = dp(MainTabsHelper.getTabsViewWidth());
+            if (tabsLp.width != baseTabsWidth) {
+                tabsLp.width = baseTabsWidth;
+                tabsView.setLayoutParams(tabsLp);
+            }
+            searchTabButton.setVisibility(View.GONE);
+            return;
+        }
+
+        int searchBtnWidth = searchTabButton.getWidth();
+        if (searchBtnWidth <= 0) {
+            searchBtnWidth = searchLp.width > 0 ? searchLp.width : dp(56);
+        }
+        int gap = searchLp.getMarginStart();
+        int endInset = searchLp.getMarginEnd();
+        int wrapperWidth = tabsViewWrapper.getWidth();
+        if (wrapperWidth <= 0) return;
+
+        int containerPadding = tabsBarContainer.getPaddingLeft() + tabsBarContainer.getPaddingRight();
+        int outerInset = dp(Math.min(DialogsActivity.MAIN_TABS_MARGIN, 6));
+        int maxTabsWidth = Math.max(0, wrapperWidth - containerPadding - searchBtnWidth - gap - endInset - outerInset * 2);
+        if (tabsLp.width != maxTabsWidth) {
+            tabsLp.width = maxTabsWidth;
+            tabsView.setLayoutParams(tabsLp);
+        }
+        searchTabButton.setVisibility(View.VISIBLE);
+
+        // Fix visual centering: the pill background is inset from tabsView bounds
+        // by bgPadding on the left, while the search button only has marginEnd on
+        // the right. Shift the container so both visual edges are equidistant from
+        // the screen edges.
+        int bgPadding = dp(MainTabsHelper.getMainTabsMargin() - 0.334f);
+        int leftVisualPad = tabsBarContainer.getPaddingLeft() + bgPadding;
+        int rightVisualPad = tabsBarContainer.getPaddingRight() + endInset;
+        float correction = (rightVisualPad - leftVisualPad) / 2f;
+        tabsBarContainer.setTranslationX(correction);
+    }
+    private void onSearchTabButtonClicked() {
+        final BaseFragment fragment = getCurrentVisibleFragment();
+        if (fragment instanceof TabFragmentDelegate) {
+            TabFragmentDelegate delegate = (TabFragmentDelegate) fragment;
+            if (delegate.hasSearch()) {
+                delegate.onSearchButtonClicked();
+                return;
+            }
+        }
+        int chatsPosition = getTabIndex(MainTabsConfigManager.TabType.CHATS);
+        if (chatsPosition >= 0 && viewPager != null) {
+            viewPager.scrollToPosition(chatsPosition);
+            if (dialogsActivity != null) {
+                dialogsActivity.onSearchButtonClicked();
+            }
+        }
+    }
+
+    private void onSearchTabButtonLongClicked() {
+        Bundle args = new Bundle();
+        args.putLong("user_id", UserConfig.getInstance(currentAccount).getClientUserId());
+        presentFragment(new ChatActivity(args));
+    }
+
+    private void updateSearchTabButtonVisibility() {
+        if (searchTabButton == null) return;
+        boolean show = NaConfig.INSTANCE.getMainTabsShowSearchButton().Bool() && !isBottomBarHidden();
+        searchTabButton.setVisibility(show ? View.VISIBLE : View.GONE);
+        if (show) {
+            View child = searchTabButton.getChildAt(0);
+            if (child instanceof ImageView) {
+                ((ImageView) child).setColorFilter(new PorterDuffColorFilter(
+                    Theme.getColor(Theme.key_glass_tabUnselected, resourceProvider), PorterDuff.Mode.SRC_IN));
+            }
+        }
+        repositionSearchButton();
+    }
 
 }
+
+
+
+
+
+

--- a/TMessagesProj/src/main/java/org/telegram/ui/MainTabsLayout.java
+++ b/TMessagesProj/src/main/java/org/telegram/ui/MainTabsLayout.java
@@ -36,44 +36,10 @@ public class MainTabsLayout extends AnimatedLinearLayout {
             return;
         }
 
-        final int maxTotalWidthForTabs = width - getPaddingLeft() - getPaddingRight();
-        if (equalWidthWhenTitlesVisible && biggestTabTextWidth > 0) {
-            // Keep the compact pill width, then split it evenly between visible tabs.
-            int equalTotalWidth = Math.min(dp(80) * visibleChildCount, maxTotalWidthForTabs);
-            int baseWidth = equalTotalWidth / visibleChildCount;
-            int remainder = equalTotalWidth % visibleChildCount;
-            int l = 0;
-            int visibleIndex = 0;
-            for (int a = 0, N = getChildCount(); a < N; a++) {
-                final View child = getChildAt(a);
-                if (!isViewVisible(child)) {
-                    tabsWidth[a] = 0;
-                    continue;
-                }
-
-                tabsWidth[a] = baseWidth + (visibleIndex < remainder ? 1 : 0);
-                tabsLeftPos[a] = l;
-                l += tabsWidth[a];
-                visibleIndex++;
-            }
-
-            setMeasuredDimension(l + getPaddingLeft() + getPaddingRight(), height);
-            for (int a = 0, N = getChildCount(); a < N; a++) {
-                final View child = getChildAt(a);
-                child.measure(
-                    MeasureSpec.makeMeasureSpec(tabsWidth[a], MeasureSpec.EXACTLY),
-                    MeasureSpec.makeMeasureSpec(tabHeight, MeasureSpec.EXACTLY));
-            }
-            calculateTotalSizesAfterMeasure();
-            return;
-        }
-
-        // Keep the per-tab minimum width, but allow the whole container to shrink
-        // when some tabs are hidden.
-        final int minTotalWidthForTabs = Math.min(dp(80) * visibleChildCount, maxTotalWidthForTabs);
+        final int maxTotalWidthForTabs = Math.max(0, width - getPaddingLeft() - getPaddingRight());
+        final int minTotalWidthForTabs = Math.min(dp(160), maxTotalWidthForTabs);
+        final int compactTabWidth = dp(biggestTabTextWidth > 0 ? 24 : 12);
         final int tabPadding = dp(16);
-
-        final int minTabTextWidthIfEq = (minTotalWidthForTabs / visibleChildCount) - tabPadding * 2;
         final int maxTabTextWidthIfEq = (maxTotalWidthForTabs / visibleChildCount) - tabPadding * 2;
 
 
@@ -87,13 +53,14 @@ public class MainTabsLayout extends AnimatedLinearLayout {
                 continue;
             }
 
-            final float w = tabsTextWidth[a];
+            final float baseTabWidth = compactTabWidth + dp(12) * 2;
+            final float w = Math.max(tabsTextWidth[a], baseTabWidth);
             if (w > maxTabTextWidthIfEq) {
-                tabsTextWidthWithMargin[a] = tabsTextWidth[a] + dp(13) * 2;
+                tabsTextWidthWithMargin[a] = w + dp(13) * 2;
             } else {
-                tabsTextWidthWithMargin[a] = tabsTextWidth[a] + dp(16) * 2;
+                tabsTextWidthWithMargin[a] = w + dp(16) * 2;
             }
-            tabsWeight[a] = tabsTextWidthWithMargin[a] > (maxTabTextWidthIfEq + dp(16) * 2) ? 0 : 1;
+            tabsWeight[a] = 1;
 
             totalWidth += tabsTextWidthWithMargin[a];
             totalWeight += tabsWeight[a];
@@ -112,31 +79,18 @@ public class MainTabsLayout extends AnimatedLinearLayout {
                 tabsTextWidthWithMargin[a] *= m;
             }
         } else if (totalWidth < minTotalWidthForTabs) {
-            final float growW = minTotalWidthForTabs - totalWidth;
+            final float targetWidth;
+            if (visibleChildCount == 1) {
+                targetWidth = Math.min(totalWidth + compactTabWidth, maxTotalWidthForTabs * 0.5f);
+            } else {
+                targetWidth = minTotalWidthForTabs;
+            }
+            final float growW = targetWidth - totalWidth;
             final float growP = growW / totalWeight;
 
-            //boolean needStage2 = false;
             for (int a = 0, N = getChildCount(); a < N; a++) {
-                final float maxGrow = maxTabTextWidthIfEq - tabsTextWidthWithMargin[a];
-                //if (tabsWeight[a] > 0 && growP * tabsWeight[a] > maxGrow) {
-                //    needStage2 = true;
-                //    tabsTextWidthWithMargin[a] = maxTabTextWidthIfEq;
-                //} else {
-                    tabsTextWidthWithMargin[a] += growP * tabsWeight[a];
-                //}
+                tabsTextWidthWithMargin[a] += growP * tabsWeight[a];
             }
-
-            /*if (needStage2) {
-                totalWidth = 0;
-                for (int a = 0, N = getChildCount(); a < N; a++) {
-                    totalWidth += tabsTextWidthWithMargin[a];
-                }
-
-                final float m = minTotalWidthForTabs / totalWidth;
-                for (int a = 0, N = getChildCount(); a < N; a++) {
-                    tabsTextWidthWithMargin[a] *= m;
-                }
-            }*/
         }
 
         int l = 0;

--- a/TMessagesProj/src/main/java/org/telegram/ui/SettingsActivity.java
+++ b/TMessagesProj/src/main/java/org/telegram/ui/SettingsActivity.java
@@ -2173,6 +2173,18 @@ public class SettingsActivity extends BaseFragment implements NotificationCenter
     }
 
     @Override
+    public void onSearchButtonClicked() {
+        if (searchItem != null) {
+            searchItem.openSearch(true);
+        }
+    }
+
+    @Override
+    public boolean hasSearch() {
+        return true;
+    }
+
+    @Override
     public boolean isSwipeBackEnabled(MotionEvent event) {
         return !animatorSearchPageVisible.getValue();
     }

--- a/TMessagesProj/src/main/java/tw/nekomimi/nekogram/settings/MainTabsCustomizeActivity.java
+++ b/TMessagesProj/src/main/java/tw/nekomimi/nekogram/settings/MainTabsCustomizeActivity.java
@@ -335,6 +335,21 @@ public class MainTabsCustomizeActivity extends BaseNekoSettingsActivity {
                 addView(tabView);
                 setViewVisible(tabView, true, false);
             }
+
+            GlassTabView searchTab = GlassTabView.createMainTab(context, resourceProvider, GlassTabView.TabAnimation.CONTACTS, R.string.Search);
+            searchTab.setIcon(R.drawable.outline_header_search);
+            searchTab.setTitleVisible(!NaConfig.INSTANCE.getMainTabsHideTitles().Bool());
+            boolean searchEnabled = NaConfig.INSTANCE.getMainTabsShowSearchButton().Bool();
+            applySearchButtonVisual(searchTab, searchEnabled);
+            searchTab.setSelected(false, false);
+            searchTab.setOnClickListener(v -> {
+                boolean checked = NaConfig.INSTANCE.getMainTabsShowSearchButton().toggleConfigBool();
+                applySearchButtonVisual(searchTab, checked);
+                NotificationCenter.getGlobalInstance().postNotificationName(NotificationCenter.mainTabsLayoutChanged);
+            });
+            addView(searchTab);
+            setViewVisible(searchTab, true, false);
+
             requestLayout();
         }
 
@@ -354,6 +369,11 @@ public class MainTabsCustomizeActivity extends BaseNekoSettingsActivity {
             tabView.setTag(state);
         }
 
+        private void applySearchButtonVisual(GlassTabView tabView, boolean enabled) {
+            tabView.setAlpha(enabled ? 1f : 0.4f);
+            tabView.setTag(Boolean.valueOf(enabled));
+        }
+
         @Override
         protected void setChildVisibilityFactor(View view, float factor) {
             float scale = org.telegram.messenger.AndroidUtilities.lerp(0.7f, 1f, factor);
@@ -361,6 +381,8 @@ public class MainTabsCustomizeActivity extends BaseNekoSettingsActivity {
             Object tag = view.getTag();
             if (tag instanceof MainTabsConfigManager.TabState state) {
                 enabledAlpha = (state.type == MainTabsConfigManager.TabType.CHATS || state.enabled) ? 1f : 0.4f;
+            } else if (tag instanceof Boolean) {
+                enabledAlpha = (Boolean) tag ? 1f : 0.4f;
             }
             view.setAlpha(factor * enabledAlpha);
             view.setScaleX(scale);

--- a/TMessagesProj/src/main/kotlin/xyz/nextalone/nagram/NaConfig.kt
+++ b/TMessagesProj/src/main/kotlin/xyz/nextalone/nagram/NaConfig.kt
@@ -1353,6 +1353,12 @@ object NaConfig {
             ConfigItem.configTypeBool,
             false
         )
+    val mainTabsShowSearchButton =
+        addConfig(
+            "MainTabsShowSearchButton",
+            ConfigItem.configTypeBool,
+            false
+        )
     val showTextMonoCode =
         addConfig(
             "TextMonoCode",


### PR DESCRIPTION
## Summary
- Add an optional search button next to the tab pills in the bottom bar
- When enabled, it replaces the floating search FAB on the home screen and provides quick access to search across Chats, Contacts, and Settings tabs
- Long-press opens Saved Messages; a toggle is available in the tab customization screen

## Test plan
- [ ] Enable search button in tab customization screen
- [ ] Verify search button appears next to tab pills
- [ ] Tap search button opens search field with keyboard
- [ ] Long-press opens Saved Messages
- [ ] Disable toggle hides search button, floating FAB returns
- [ ] Verify layout adapts with different tab counts