### PR TITLE
feat: add send premium emoji as sticker option

### DIFF
--- a/TMessagesProj/src/main/java/org/telegram/ui/Cells/FeaturedStickerSetCell2.java
+++ b/TMessagesProj/src/main/java/org/telegram/ui/Cells/FeaturedStickerSetCell2.java
@@ -299,7 +299,7 @@ public class FeaturedStickerSetCell2 extends FrameLayout implements Notification
         addButton.setVisibility(VISIBLE);
         this.forceInstalled = forceInstalled;
         isInstalled = forceInstalled || MediaDataController.getInstance(currentAccount).isStickerPackInstalled(set.set.id);
-        isLocked = !UserConfig.getInstance(currentAccount).isPremium() && MessageObject.isPremiumEmojiPack(set);
+        isLocked = !UserConfig.getInstance(currentAccount).isPremium() && MessageObject.isPremiumEmojiPack(set) && (set.set == null || !set.set.emojis);
         if (animated) {
             if (isLocked) {
                 unlockButton.setVisibility(VISIBLE);

--- a/TMessagesProj/src/main/java/org/telegram/ui/Cells/StickerSetCell.java
+++ b/TMessagesProj/src/main/java/org/telegram/ui/Cells/StickerSetCell.java
@@ -718,27 +718,7 @@ public class StickerSetCell extends FrameLayout {
             cell.premiumButtonView.setOnClickListener(item.clickCallback2);
             if (set != null && set.set != null && set.set.emojis) {
                 boolean installed = MediaDataController.getInstance(adapter.currentAccount).isStickerPackInstalled(set.set.id);
-                boolean unlock = !UserConfig.getInstance(adapter.currentAccount).isPremium();
-                if (unlock) {
-                    boolean premium = false;
-                    for (int i = 0; i < set.documents.size(); ++i) {
-                        if (!MessageObject.isFreeEmoji(set.documents.get(i))) {
-                            premium = true;
-                            break;
-                        }
-                    }
-                    if (!premium) {
-                        unlock = false;
-                    }
-                }
-                cell.updateButtonState(
-                    unlock ? (
-                        installed && !set.set.official ? StickerSetCell.BUTTON_STATE_LOCKED_RESTORE : StickerSetCell.BUTTON_STATE_LOCKED
-                    ) : (
-                        installed ? StickerSetCell.BUTTON_STATE_REMOVE : StickerSetCell.BUTTON_STATE_ADD
-                    ),
-                    false
-                );
+                cell.updateButtonState(installed ? StickerSetCell.BUTTON_STATE_REMOVE : StickerSetCell.BUTTON_STATE_ADD, false);
             }
         }
 

--- a/TMessagesProj/src/main/java/org/telegram/ui/Components/ChatActivityEnterView.java
+++ b/TMessagesProj/src/main/java/org/telegram/ui/Components/ChatActivityEnterView.java
@@ -700,6 +700,24 @@ public class ChatActivityEnterView extends FrameLayout implements
 
     private TLRPC.ChatFull info;
 
+    private static class PendingCustomEmojiStickerSend {
+        final TLRPC.Document document;
+        final String emoticon;
+        final boolean notify;
+        final int scheduleDate;
+        final int scheduleRepeatPeriod;
+
+        private PendingCustomEmojiStickerSend(TLRPC.Document document, String emoticon, boolean notify, int scheduleDate, int scheduleRepeatPeriod) {
+            this.document = document;
+            this.emoticon = emoticon;
+            this.notify = notify;
+            this.scheduleDate = scheduleDate;
+            this.scheduleRepeatPeriod = scheduleRepeatPeriod;
+        }
+    }
+
+    private final HashMap<String, ArrayList<PendingCustomEmojiStickerSend>> pendingCustomEmojiStickerSends = new HashMap<>();
+
     private boolean hasRecordVideo;
 
     private int currentPopupContentType = -1;
@@ -2643,6 +2661,8 @@ public class ChatActivityEnterView extends FrameLayout implements
         NotificationCenter.getInstance(currentAccount).addObserver(this, NotificationCenter.audioRecordTooShort);
         NotificationCenter.getInstance(currentAccount).addObserver(this, NotificationCenter.updateBotMenuButton);
         NotificationCenter.getInstance(currentAccount).addObserver(this, NotificationCenter.didUpdatePremiumGiftFieldIcon);
+        NotificationCenter.getInstance(currentAccount).addObserver(this, NotificationCenter.fileLoaded);
+        NotificationCenter.getInstance(currentAccount).addObserver(this, NotificationCenter.fileLoadFailed);
         NotificationCenter.getGlobalInstance().addObserver(this, NotificationCenter.emojiLoaded);
 
         parentActivity = context;
@@ -7042,6 +7062,9 @@ if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.VANILLA_ICE_CREAM) {
         NotificationCenter.getInstance(currentAccount).removeObserver(this, NotificationCenter.audioRecordTooShort);
         NotificationCenter.getInstance(currentAccount).removeObserver(this, NotificationCenter.updateBotMenuButton);
         NotificationCenter.getInstance(currentAccount).removeObserver(this, NotificationCenter.didUpdatePremiumGiftFieldIcon);
+        NotificationCenter.getInstance(currentAccount).removeObserver(this, NotificationCenter.fileLoaded);
+        NotificationCenter.getInstance(currentAccount).removeObserver(this, NotificationCenter.fileLoadFailed);
+        pendingCustomEmojiStickerSends.clear();
         NotificationCenter.getGlobalInstance().removeObserver(this, NotificationCenter.emojiLoaded);
         if (emojiView != null) {
             emojiView.onDestroy();
@@ -7225,6 +7248,9 @@ if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.VANILLA_ICE_CREAM) {
             NotificationCenter.getInstance(currentAccount).removeObserver(this, NotificationCenter.featuredStickersDidLoad);
             NotificationCenter.getInstance(currentAccount).removeObserver(this, NotificationCenter.messageReceivedByServer2);
             NotificationCenter.getInstance(currentAccount).removeObserver(this, NotificationCenter.sendingMessagesChanged);
+            NotificationCenter.getInstance(currentAccount).removeObserver(this, NotificationCenter.fileLoaded);
+            NotificationCenter.getInstance(currentAccount).removeObserver(this, NotificationCenter.fileLoadFailed);
+            pendingCustomEmojiStickerSends.clear();
             currentAccount = account;
             accountInstance = AccountInstance.getInstance(currentAccount);
             NotificationCenter.getInstance(currentAccount).addObserver(this, NotificationCenter.recordStarted);
@@ -7241,6 +7267,8 @@ if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.VANILLA_ICE_CREAM) {
             NotificationCenter.getInstance(currentAccount).addObserver(this, NotificationCenter.featuredStickersDidLoad);
             NotificationCenter.getInstance(currentAccount).addObserver(this, NotificationCenter.messageReceivedByServer2);
             NotificationCenter.getInstance(currentAccount).addObserver(this, NotificationCenter.sendingMessagesChanged);
+            NotificationCenter.getInstance(currentAccount).addObserver(this, NotificationCenter.fileLoaded);
+            NotificationCenter.getInstance(currentAccount).addObserver(this, NotificationCenter.fileLoadFailed);
         }
 
         sendPlainEnabled = true;
@@ -12356,7 +12384,35 @@ if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.VANILLA_ICE_CREAM) {
                 }
             }
 
-    public void onCustomEmojiSelected(long documentId, TLRPC.Document document, String emoticon, boolean isRecent) {
+            @Override
+            public boolean allowNonPremiumCustomEmoji() {
+                return !UserConfig.getInstance(currentAccount).isPremium()
+                    && NaConfig.INSTANCE.getSendLockedCustomEmojiAsSticker().Bool()
+                    && dialog_id != UserConfig.getInstance(currentAccount).getClientUserId();
+            }
+
+            @Override
+            public boolean canShowNonPremiumCustomEmoji(TLRPC.Document document) {
+                return allowNonPremiumCustomEmoji()
+                    && document != null
+                    && !ChatActivityEnterView.this.isGroupEmojiDocument(document)
+                    && ChatActivityEnterView.this.isCustomEmojiStickerMime(document);
+            }
+
+            @Override
+            public boolean onNonPremiumCustomEmojiSelected(long documentId, TLRPC.Document document, String emoticon, boolean isRecent) {
+                if (!canShowNonPremiumCustomEmoji(document)) {
+                    return false;
+                }
+                if (!stickersEnabled) {
+                    ChatActivityEnterView.this.showRestrictedHint();
+                    return true;
+                }
+                return ChatActivityEnterView.this.sendCustomEmojiAsUploadedSticker(document, emoticon, true, 0, 0);
+            }
+
+            @Override
+            public void onCustomEmojiSelected(long documentId, TLRPC.Document document, String emoticon, boolean isRecent) {
                 final EditTextBoldCursor messageEditText = mOverrideEditTextView != null ?
                     mOverrideEditTextView : ChatActivityEnterView.this.messageEditText;
                 AndroidUtilities.runOnUIThread(() -> {
@@ -13041,6 +13097,170 @@ if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.VANILLA_ICE_CREAM) {
         }
         attachEmojiView();
         checkChannelRights();
+    }
+
+    private boolean isGroupEmojiDocument(TLRPC.Document document) {
+        if (document == null || info == null || info.emojiset == null) {
+            return false;
+        }
+        TLRPC.InputStickerSet inputStickerSet = MessageObject.getInputStickerSet(document);
+        return inputStickerSet instanceof TLRPC.TL_inputStickerSetID && ((TLRPC.TL_inputStickerSetID) inputStickerSet).id == info.emojiset.id;
+    }
+
+    private boolean isCustomEmojiStickerMime(TLRPC.Document document) {
+        if (document == null) {
+            return false;
+        }
+        String mimeType = document.mime_type != null ? document.mime_type : "";
+        return "image/webp".equals(mimeType) || "video/webm".equals(mimeType);
+    }
+
+    private boolean sendCustomEmojiAsUploadedSticker(TLRPC.Document customEmojiDocument, String emoticon, boolean notify, int scheduleDate, int scheduleRepeatPeriod) {
+        if (isLiveComment) {
+            return false;
+        }
+        if (replyingQuote != null && parentFragment != null && replyingQuote.outdated) {
+            parentFragment.showQuoteMessageUpdate();
+            return false;
+        }
+        if (customEmojiDocument == null) {
+            return false;
+        }
+
+        final String sourceMime = customEmojiDocument.mime_type != null ? customEmojiDocument.mime_type : "";
+        if (!isCustomEmojiStickerMime(customEmojiDocument)) {
+            return false;
+        }
+
+        if (isInScheduleMode() && scheduleDate == 0) {
+            AlertsCreator.createScheduleDatePickerDialog(parentActivity, parentFragment.getDialogId(), (n, s, r) -> sendCustomEmojiAsUploadedSticker(customEmojiDocument, emoticon, n, s, r), resourcesProvider);
+            return true;
+        }
+        if (slowModeTimer > 0 && !isInScheduleMode()) {
+            if (delegate != null) {
+                delegate.onUpdateSlowModeButton(slowModeButton, true, slowModeButton.getText());
+            }
+            return true;
+        }
+
+        File file = FileLoader.getInstance(currentAccount).getPathToAttach(customEmojiDocument);
+        if (file == null || !file.exists()) {
+            File cacheFile = FileLoader.getInstance(currentAccount).getPathToAttach(customEmojiDocument, true);
+            if (cacheFile != null && cacheFile.exists()) {
+                file = cacheFile;
+            }
+        }
+        if (file == null || !file.exists()) {
+            String fileName = FileLoader.getAttachFileName(customEmojiDocument);
+            if (TextUtils.isEmpty(fileName)) {
+                return false;
+            }
+            ArrayList<PendingCustomEmojiStickerSend> pendingSends = pendingCustomEmojiStickerSends.get(fileName);
+            boolean shouldLoadFile = pendingSends == null;
+            if (pendingSends == null) {
+                pendingSends = new ArrayList<>();
+                pendingCustomEmojiStickerSends.put(fileName, pendingSends);
+            }
+            pendingSends.add(new PendingCustomEmojiStickerSend(customEmojiDocument, emoticon, notify, scheduleDate, scheduleRepeatPeriod));
+            if (shouldLoadFile) {
+                FileLoader.getInstance(currentAccount).loadFile(customEmojiDocument, null, FileLoader.PRIORITY_NORMAL, 1);
+            }
+            return true;
+        }
+
+        final File fileFinal = file;
+        final String uploadMimeFinal = sourceMime;
+        AlertsCreator.ensurePaidMessageConfirmation(currentAccount, dialog_id, 1, stars -> {
+            Runnable runnable = () -> {
+                if (delegate != null) {
+                    delegate.beforeMessageSend(null, notify, scheduleDate, stars);
+                }
+                if (searchingType != 0) {
+                    setSearchingTypeInternal(0, true);
+                    emojiView.closeSearch(true);
+                    emojiView.hideSearchKeyboard();
+                }
+                setStickersExpanded(false, true, false);
+                final TL_stories.StoryItem storyItem = delegate != null ? delegate.getReplyToStory() : null;
+
+                TLRPC.TL_document uploadDocument = new TLRPC.TL_document();
+                uploadDocument.id = 0;
+                uploadDocument.date = accountInstance.getConnectionsManager().getCurrentTime();
+                uploadDocument.file_reference = new byte[0];
+                uploadDocument.size = fileFinal.length();
+                uploadDocument.dc_id = 0;
+                uploadDocument.mime_type = uploadMimeFinal;
+
+                TLRPC.TL_documentAttributeFilename fileName = new TLRPC.TL_documentAttributeFilename();
+                fileName.file_name = "video/webm".equals(uploadDocument.mime_type) ? "sticker.webm" : "sticker.webp";
+                uploadDocument.attributes.add(fileName);
+
+                boolean hasStickerAttribute = false;
+                boolean hasAnimatedAttribute = false;
+                boolean hasVideoAttribute = false;
+                int videoW = 512;
+                int videoH = 512;
+                for (int i = 0; i < customEmojiDocument.attributes.size(); i++) {
+                    TLRPC.DocumentAttribute attribute = customEmojiDocument.attributes.get(i);
+                    if (attribute instanceof TLRPC.TL_documentAttributeCustomEmoji || attribute instanceof TLRPC.TL_documentAttributeSticker) {
+                        TLRPC.TL_documentAttributeSticker stickerAttribute = new TLRPC.TL_documentAttributeSticker();
+                        stickerAttribute.alt = !TextUtils.isEmpty(emoticon) ? emoticon : attribute.alt;
+                        stickerAttribute.stickerset = new TLRPC.TL_inputStickerSetEmpty();
+                        uploadDocument.attributes.add(stickerAttribute);
+                        hasStickerAttribute = true;
+                    } else {
+                        if (attribute instanceof TLRPC.TL_documentAttributeFilename) {
+                            continue;
+                        }
+                        if (attribute instanceof TLRPC.TL_documentAttributeAnimated) {
+                            hasAnimatedAttribute = true;
+                        } else if (attribute instanceof TLRPC.TL_documentAttributeVideo) {
+                            hasVideoAttribute = true;
+                            videoW = Math.max(1, attribute.w);
+                            videoH = Math.max(1, attribute.h);
+                        }
+                        uploadDocument.attributes.add(attribute);
+                    }
+                }
+                if (!hasStickerAttribute) {
+                    TLRPC.TL_documentAttributeSticker stickerAttribute = new TLRPC.TL_documentAttributeSticker();
+                    stickerAttribute.alt = emoticon != null ? emoticon : "";
+                    stickerAttribute.stickerset = new TLRPC.TL_inputStickerSetEmpty();
+                    uploadDocument.attributes.add(stickerAttribute);
+                }
+
+                if ("video/webm".equals(uploadDocument.mime_type)) {
+                    if (!hasVideoAttribute) {
+                        TLRPC.TL_documentAttributeVideo videoAttribute = new TLRPC.TL_documentAttributeVideo();
+                        videoAttribute.w = videoW;
+                        videoAttribute.h = videoH;
+                        videoAttribute.duration = 0;
+                        uploadDocument.attributes.add(videoAttribute);
+                    }
+                    if (!hasAnimatedAttribute) {
+                        uploadDocument.attributes.add(new TLRPC.TL_documentAttributeAnimated());
+                    }
+                }
+
+                SendMessagesHelper.SendMessageParams sendMessageParams = SendMessagesHelper.SendMessageParams.of(uploadDocument, null, fileFinal.getAbsolutePath(), dialog_id, replyingMessageObject, getThreadMessage(), null, null, null, null, notify, scheduleDate, scheduleRepeatPeriod, 0, null, null, false);
+                sendMessageParams.replyToStoryItem = storyItem;
+                sendMessageParams.replyQuote = replyingQuote;
+                sendMessageParams.quick_reply_shortcut = parentFragment != null ? parentFragment.quickReplyShortcut : null;
+                sendMessageParams.quick_reply_shortcut_id = parentFragment != null ? parentFragment.getQuickReplyId() : 0;
+                sendMessageParams.payStars = stars;
+                sendMessageParams.monoForumPeer = getSendMonoForumPeerId();
+                sendMessageParams.suggestionParams = getSendMessageSuggestionParams();
+                SendMessagesHelper.getInstance(currentAccount).sendMessage(sendMessageParams);
+
+                if (delegate != null) {
+                    delegate.onMessageSend(null, notify, scheduleDate, scheduleRepeatPeriod, stars);
+                }
+            };
+            if (!showConfirmAlert(runnable)) {
+                runnable.run();
+            }
+        });
+        return true;
     }
 
     @Override
@@ -13782,6 +14002,16 @@ if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.VANILLA_ICE_CREAM) {
     @SuppressWarnings("unchecked")
     @Override
     public void didReceivedNotification(int id, int account, Object... args) {
+        if (id == NotificationCenter.fileLoaded || id == NotificationCenter.fileLoadFailed) {
+            ArrayList<PendingCustomEmojiStickerSend> pendingSends = args[0] instanceof String ? pendingCustomEmojiStickerSends.remove(args[0]) : null;
+            if (pendingSends != null && id == NotificationCenter.fileLoaded) {
+                for (int i = 0; i < pendingSends.size(); i++) {
+                    PendingCustomEmojiStickerSend pendingSend = pendingSends.get(i);
+                    sendCustomEmojiAsUploadedSticker(pendingSend.document, pendingSend.emoticon, pendingSend.notify, pendingSend.scheduleDate, pendingSend.scheduleRepeatPeriod);
+                }
+            }
+            return;
+        }
         if (id == NotificationCenter.emojiLoaded) {
             if (emojiView != null) {
                 emojiView.invalidateViews();

--- a/TMessagesProj/src/main/java/org/telegram/ui/Components/EmojiPacksAlert.java
+++ b/TMessagesProj/src/main/java/org/telegram/ui/Components/EmojiPacksAlert.java
@@ -1100,6 +1100,11 @@ public class EmojiPacksAlert extends BottomSheet implements NotificationCenter.N
     }
 
     boolean loaded = true;
+
+    private boolean shouldShowUnlockForPack(TLRPC.TL_messages_stickerSet stickerSet) {
+        return !UserConfig.getInstance(currentAccount).isPremium() && stickerSet != null && stickerSet.set != null && !stickerSet.set.emojis && MessageObject.isPremiumEmojiPack(stickerSet);
+    }
+
     private void updateButton() {
         if (buttonsView == null) {
             return;
@@ -1376,17 +1381,8 @@ public class EmojiPacksAlert extends BottomSheet implements NotificationCenter.N
                         j += 1 + sz + 1;
                     }
                     TLRPC.TL_messages_stickerSet stickerSet = customEmojiPacks.stickerSets == null || i >= customEmojiPacks.stickerSets.size() ? null : customEmojiPacks.stickerSets.get(i);
-                    boolean premium = false;
-                    if (stickerSet != null && stickerSet.documents != null) {
-                        for (int j = 0; j < stickerSet.documents.size(); ++j) {
-                            if (!MessageObject.isFreeEmoji(stickerSet.documents.get(j))) {
-                                premium = true;
-                                break;
-                            }
-                        }
-                    }
                     if (i < customEmojiPacks.data.length) {
-                        ((EmojiPackHeader) holder.itemView).set(stickerSet, stickerSet == null || stickerSet.documents == null ? 0 : stickerSet.documents.size(), premium);
+                        ((EmojiPackHeader) holder.itemView).set(stickerSet, stickerSet == null || stickerSet.documents == null ? 0 : stickerSet.documents.size(), shouldShowUnlockForPack(stickerSet));
                     }
                     break;
             }
@@ -1460,7 +1456,7 @@ public class EmojiPacksAlert extends BottomSheet implements NotificationCenter.N
 
         @Override
         public int getItemCount() {
-            hasDescription = !UserConfig.getInstance(currentAccount).isPremium() && customEmojiPacks.stickerSets != null && customEmojiPacks.stickerSets.size() == 1 && MessageObject.isPremiumEmojiPack(customEmojiPacks.stickerSets.get(0));
+            hasDescription = customEmojiPacks.stickerSets != null && customEmojiPacks.stickerSets.size() == 1 && shouldShowUnlockForPack(customEmojiPacks.stickerSets.get(0));
             return 1 + (hasDescription ? 1 : 0) + customEmojiPacks.getItemsCount() + Math.max(0, customEmojiPacks.data.length - 1);
         }
     }

--- a/TMessagesProj/src/main/java/org/telegram/ui/Components/EmojiTabsStrip.java
+++ b/TMessagesProj/src/main/java/org/telegram/ui/Components/EmojiTabsStrip.java
@@ -516,7 +516,15 @@ public class EmojiTabsStrip extends ScrollableHorizontalScrollView {
             return;
         }
         final boolean isPremium = UserConfig.getInstance(UserConfig.selectedAccount).isPremium() || allowEmojisForNonPremium();
-        if (NekoConfig.disableTrending.Bool() && !isPremium) {
+        boolean hasInstalledUnlockedPacks = false;
+        for (int i = 0; i < emojiPacks.size(); ++i) {
+            EmojiView.EmojiPack pack = emojiPacks.get(i);
+            if (pack != null && isInstalled(pack) && (pack.free || pack.enabledForNonPremium) && !pack.featured) {
+                hasInstalledUnlockedPacks = true;
+                break;
+            }
+        }
+        if (NekoConfig.disableTrending.Bool() && !isPremium && !hasInstalledUnlockedPacks) {
             return;
         }
         int childCount = contentView.getChildCount() - packsIndexStart - (settingsTab != null ? 1 : 0);
@@ -556,7 +564,7 @@ public class EmojiTabsStrip extends ScrollableHorizontalScrollView {
                     currentPackButton.setLock(null, false);
                 }
             } else {
-                final boolean free = newPack.free;
+                final boolean free = newPack.free || newPack.enabledForNonPremium && isInstalled(newPack) && !newPack.featured;
                 if (newPack.thumbDocumentId != null) {
                     if (currentPackButton == null) {
                         currentPackButton = new EmojiTabButton(getContext(), newPack.thumbDocumentId, free, false, false);

--- a/TMessagesProj/src/main/java/org/telegram/ui/Components/EmojiView.java
+++ b/TMessagesProj/src/main/java/org/telegram/ui/Components/EmojiView.java
@@ -416,6 +416,18 @@ public class EmojiView extends FrameLayout implements NotificationCenter.Notific
 
         }
 
+        default boolean onNonPremiumCustomEmojiSelected(long documentId, TLRPC.Document document, String emoticon, boolean isRecent) {
+            return false;
+        }
+
+        default boolean allowNonPremiumCustomEmoji() {
+            return false;
+        }
+
+        default boolean canShowNonPremiumCustomEmoji(TLRPC.Document document) {
+            return false;
+        }
+
         default void onStickerSelected(View view, TLRPC.Document sticker, String query, Object parent, MessageObject.SendAnimationData sendAnimationData, boolean notify, int scheduleDate, int scheduleRepeatPeriod) {
 
         }
@@ -1370,6 +1382,13 @@ public class EmojiView extends FrameLayout implements NotificationCenter.Notific
                     emoticon = MessageObject.findAnimatedEmojiEmoticon(document);
                 }
                 if (!MessageObject.isFreeEmoji(document) && !UserConfig.getInstance(currentAccount).isPremium() && !(delegate != null && delegate.isUserSelf()) && !allowEmojisForNonPremium && !isGroupEmojis) {
+                    if (delegate != null && delegate.onNonPremiumCustomEmojiSelected(documentId, document, emoticon, imageViewEmoji.isRecent)) {
+                        shownBottomTabAfterClick = SystemClock.elapsedRealtime();
+                        showBottomTab(true, true);
+                        addEmojiToRecent("animated_" + documentId);
+                        return;
+                    }
+
                     showBottomTab(false, true);
                     BulletinFactory factory = fragment != null ? BulletinFactory.of(fragment) : BulletinFactory.of(bulletinContainer, resourcesProvider);
                     if (premiumBulletin || fragment == null) {
@@ -3483,7 +3502,7 @@ public class EmojiView extends FrameLayout implements NotificationCenter.Notific
             final float itemSize = (getMeasuredWidth() - getPaddingLeft() - getPaddingRight()) / (float) emojiLayoutManager.getSpanCount();
             for (int i = 0; i < emojiAdapter.packStartPosition.size(); ++i) {
                 EmojiPack pack = i < emojipacksProcessed.size() ? emojipacksProcessed.get(i) : null;
-                if (pack == null || !((pack.installed || installedEmojiSets.contains(pack.set.id)) && !pack.featured && !pack.free)) {
+                if (pack == null || !((pack.installed || installedEmojiSets.contains(pack.set.id)) && !pack.featured && !pack.free && !pack.enabledForNonPremium)) {
                     continue;
                 }
                 int start = emojiAdapter.packStartPosition.get(i);
@@ -4122,7 +4141,7 @@ public class EmojiView extends FrameLayout implements NotificationCenter.Notific
             }
             int state = BUTTON_STATE_EMPTY;
             boolean installed = pack.installed || installedEmojiSets.contains(pack.set.id);
-            if (!pack.free && !UserConfig.getInstance(currentAccount).isPremium() && !allowEmojisForNonPremium) {
+            if (!UserConfig.getInstance(currentAccount).isPremium() && !allowEmojisForNonPremium && !isPackAvailableWithoutPremium(pack)) {
                 state = BUTTON_STATE_LOCKED;
             } else if (pack.featured) {
                 if (installed) {
@@ -5904,6 +5923,12 @@ public class EmojiView extends FrameLayout implements NotificationCenter.Notific
 
     public void setDelegate(EmojiViewDelegate emojiViewDelegate) {
         delegate = emojiViewDelegate;
+        if (emojiAdapter != null) {
+            emojiAdapter.notifyDataSetChanged(true);
+        }
+        if (emojiTabs != null) {
+            emojiTabs.updateEmojiPacks(getEmojipacks());
+        }
     }
 
     public void setDragListener(DragListener listener) {
@@ -7058,12 +7083,24 @@ public class EmojiView extends FrameLayout implements NotificationCenter.Notific
         public ArrayList<TLRPC.Document> documents = new ArrayList<>();
         public TLRPC.InputStickerSet needLoadSet;
         public boolean free;
+        public boolean enabledForNonPremium;
         public boolean installed;
         public boolean featured;
         public boolean expanded;
         public boolean forGroup;
 
         public int resId;
+    }
+
+    private boolean isPackAvailableWithoutPremium(EmojiPack pack) {
+        if (pack == null) {
+            return false;
+        }
+        return pack.free || pack.enabledForNonPremium && !pack.featured && (pack.installed || installedEmojiSets.contains(pack.set.id));
+    }
+
+    private boolean isPackFullyAccessible(EmojiPack pack, boolean isPremium) {
+        return pack != null && (isPremium || isPackAvailableWithoutPremium(pack));
     }
 
     private class EmojiGridAdapter extends RecyclerListView.SelectionAdapter {
@@ -7249,7 +7286,7 @@ public class EmojiView extends FrameLayout implements NotificationCenter.Notific
                             for (int b = 0; b < packStartPosition.size(); ++b) {
                                 EmojiPack pack = emojipacksProcessed.get(b);
                                 int start = packStartPosition.get(b) + 1;
-                                int stickersCount = ((pack.installed && !pack.featured) && (pack.free || isPremium) || pack.expanded ? pack.documents.size() : Math.min(maxlen, pack.documents.size()));
+                                int stickersCount = ((pack.installed && !pack.featured) && isPackFullyAccessible(pack, isPremium) || pack.expanded ? pack.documents.size() : Math.min(maxlen, pack.documents.size()));
                                 if (imageView.position >= start && imageView.position - start < stickersCount) {
                                     imageView.pack = pack;
                                     customEmoji = pack.documents.get(imageView.position - start);
@@ -7353,7 +7390,7 @@ public class EmojiView extends FrameLayout implements NotificationCenter.Notific
                     int a = section - emojiTitles.length;
                     EmojiPack pack2 = emojipacksProcessed.get(a);
                     EmojiPack before = a - 1 >= 0 ? emojipacksProcessed.get(a - 1) : null;
-                    boolean divider = pack2 != null && pack2.featured && !(before != null && !before.free && before.installed && !UserConfig.getInstance(currentAccount).isPremium());
+                    boolean divider = pack2 != null && pack2.featured && !(before != null && before.installed && !UserConfig.getInstance(currentAccount).isPremium() && !isPackAvailableWithoutPremium(before));
                     if (pack2 != null && pack2.needLoadSet != null) {
                         MediaDataController.getInstance(currentAccount).getStickerSet(pack2.needLoadSet, false);
                         pack2.needLoadSet = null;
@@ -7403,6 +7440,7 @@ public class EmojiView extends FrameLayout implements NotificationCenter.Notific
             }
             ArrayList<TLRPC.TL_messages_stickerSet> installedEmojipacks = frozenEmojiPacks;
             boolean isPremium = UserConfig.getInstance(currentAccount).isPremium() || allowEmojisForNonPremium;
+            boolean filterLockedEmojiByDelegate = !UserConfig.getInstance(currentAccount).isPremium() && !allowEmojisForNonPremium && delegate != null && delegate.allowNonPremiumCustomEmoji();
             int index = 0;
 
             if (info != null && info.emojiset != null) {
@@ -7442,6 +7480,9 @@ public class EmojiView extends FrameLayout implements NotificationCenter.Notific
             for (int i = 0; i < installedEmojipacks.size(); ++i) {
                 TLRPC.TL_messages_stickerSet set = installedEmojipacks.get(i);
                 if (isPremium) {
+                    if (set.documents == null || set.documents.isEmpty()) {
+                        continue;
+                    }
                     EmojiPack pack = new EmojiPack();
                     pack.index = index++;
                     pack.set = set.set;
@@ -7456,10 +7497,11 @@ public class EmojiView extends FrameLayout implements NotificationCenter.Notific
                     ArrayList<TLRPC.Document> premiumEmojis = new ArrayList<>();
                     if (set != null && set.documents != null) {
                         for (int j = 0; j < set.documents.size(); ++j) {
-                            if (MessageObject.isFreeEmoji(set.documents.get(j))) {
-                                freeEmojis.add(set.documents.get(j));
-                            } else {
-                                premiumEmojis.add(set.documents.get(j));
+                            TLRPC.Document emoji = set.documents.get(j);
+                            if (MessageObject.isFreeEmoji(emoji)) {
+                                freeEmojis.add(emoji);
+                            } else if (!filterLockedEmojiByDelegate || delegate.canShowNonPremiumCustomEmoji(emoji)) {
+                                premiumEmojis.add(emoji);
                             }
                         }
                     }
@@ -7480,6 +7522,7 @@ public class EmojiView extends FrameLayout implements NotificationCenter.Notific
                         pack.set = set.set;
                         pack.documents = new ArrayList<>(premiumEmojis);
                         pack.free = false;
+                        pack.enabledForNonPremium = filterLockedEmojiByDelegate;
                         pack.installed = mediaDataController.isStickerPackInstalled(set.set.id);
                         pack.featured = false;
                         pack.expanded = expandedEmojiSets.contains(pack.set.id);
@@ -7506,6 +7549,16 @@ public class EmojiView extends FrameLayout implements NotificationCenter.Notific
                     }
                 } else {
                     pack.documents = set.covers;
+                }
+                if (filterLockedEmojiByDelegate && pack.documents != null) {
+                    ArrayList<TLRPC.Document> filteredDocuments = new ArrayList<>();
+                    for (int j = 0; j < pack.documents.size(); ++j) {
+                        TLRPC.Document emoji = pack.documents.get(j);
+                        if (MessageObject.isFreeEmoji(emoji) || delegate.canShowNonPremiumCustomEmoji(emoji)) {
+                            filteredDocuments.add(emoji);
+                        }
+                    }
+                    pack.documents = filteredDocuments;
                 }
                 if (pack.documents == null || pack.documents.isEmpty()) {
                     continue;
@@ -7545,7 +7598,7 @@ public class EmojiView extends FrameLayout implements NotificationCenter.Notific
 
             boolean isPremium = UserConfig.getInstance(currentAccount).isPremium() || allowEmojisForNonPremium;
             int maxlen = emojiLayoutManager.getSpanCount() * 3;
-            int fromCount = ((pack.installed && !pack.featured) && (pack.free || isPremium) || pack.expanded ? pack.documents.size() : Math.min(maxlen, pack.documents.size()));
+            int fromCount = ((pack.installed && !pack.featured) && isPackFullyAccessible(pack, isPremium) || pack.expanded ? pack.documents.size() : Math.min(maxlen, pack.documents.size()));
             Integer from = null, count = null;
             if (pack.documents.size() > maxlen) {
                 from = start + 1 + fromCount;
@@ -7644,7 +7697,7 @@ public class EmojiView extends FrameLayout implements NotificationCenter.Notific
                     if (pack.featured && firstTrendingRow < 0) {
                         firstTrendingRow = itemCount;
                     }
-                    int count = 1 + ((pack.installed && !pack.featured) && (pack.free || isPremium) || pack.expanded ? pack.documents.size() : Math.min(maxlen, pack.documents.size()));
+                    int count = 1 + ((pack.installed && !pack.featured) && isPackFullyAccessible(pack, isPremium) || pack.expanded ? pack.documents.size() : Math.min(maxlen, pack.documents.size()));
                     if (!pack.expanded && pack.documents.size() > maxlen) {
                         count--;
                     }
@@ -8022,7 +8075,7 @@ public class EmojiView extends FrameLayout implements NotificationCenter.Notific
                                     searchResult.addAll(param);
 
                                     next.run();
-                                }, null, SharedConfig.suggestAnimatedEmoji || UserConfig.getInstance(currentAccount).isPremium(), false, true, 25);
+                                }, null, SharedConfig.suggestAnimatedEmoji || UserConfig.getInstance(currentAccount).isPremium() || delegate != null && delegate.allowNonPremiumCustomEmoji(), false, true, 25);
                             },
                             next -> {
                                 if (ConnectionsManager.getInstance(currentAccount).getConnectionState() != ConnectionsManager.ConnectionStateConnected) {
@@ -8036,7 +8089,8 @@ public class EmojiView extends FrameLayout implements NotificationCenter.Notific
                                     }
                                     AnimatedEmojiDrawable.getDocumentFetcher(currentAccount).putDocuments(emojis);
                                     for (TLRPC.Document emoji : emojis) {
-                                        if (!UserConfig.getInstance(currentAccount).isPremium() && !MessageObject.isFreeEmoji(emoji) && !(delegate != null && delegate.isUserSelf())) {
+                                        boolean allowLockedEmoji = delegate != null && delegate.canShowNonPremiumCustomEmoji(emoji);
+                                        if (!UserConfig.getInstance(currentAccount).isPremium() && !MessageObject.isFreeEmoji(emoji) && !(delegate != null && delegate.isUserSelf()) && !allowLockedEmoji) {
                                             continue;
                                         }
                                         MediaDataController.KeywordResult keywordResult = new MediaDataController.KeywordResult();
@@ -8048,7 +8102,7 @@ public class EmojiView extends FrameLayout implements NotificationCenter.Notific
                                 });
                             },
                             next -> {
-                                if (SharedConfig.suggestAnimatedEmoji || UserConfig.getInstance(currentAccount).isPremium()) {
+                                if (SharedConfig.suggestAnimatedEmoji || UserConfig.getInstance(currentAccount).isPremium() || delegate != null && delegate.allowNonPremiumCustomEmoji()) {
                                     final String q = translitSafe((query + "").toLowerCase());
                                     final ArrayList<TLRPC.TL_messages_stickerSet> sets = MediaDataController.getInstance(currentAccount).getStickerSets(MediaDataController.TYPE_EMOJIPACKS);
 

--- a/TMessagesProj/src/main/java/tw/nekomimi/nekogram/settings/NekoExperimentalSettingsActivity.java
+++ b/TMessagesProj/src/main/java/tw/nekomimi/nekogram/settings/NekoExperimentalSettingsActivity.java
@@ -82,6 +82,7 @@ public class NekoExperimentalSettingsActivity extends BaseNekoXSettingsActivity 
             }, null));
     private final AbstractConfigCell springAnimationCrossfadeRow = cellGroup.appendCell(new ConfigCellTextCheck(NaConfig.INSTANCE.getSpringAnimationCrossfade()));
     private final AbstractConfigCell localPremiumRow = cellGroup.appendCell(new ConfigCellTextCheck(NekoConfig.localPremium));
+    private final AbstractConfigCell sendLockedCustomEmojiAsStickerRow = cellGroup.appendCell(new ConfigCellTextCheck(NaConfig.INSTANCE.getSendLockedCustomEmojiAsSticker(), getString(R.string.SendLockedCustomEmojiAsStickerInfo)));
     private final AbstractConfigCell unlimitedPinnedDialogsRow = cellGroup.appendCell(new ConfigCellTextCheck(NekoConfig.unlimitedPinnedDialogs, getString(R.string.UnlimitedPinnedDialogsAbout)));
     private final AbstractConfigCell unlimitedFavedStickersRow = cellGroup.appendCell(new ConfigCellTextCheck(NekoConfig.unlimitedFavedStickers, getString(R.string.UnlimitedFavoredStickersAbout)));
     private final AbstractConfigCell dividerGeneral = cellGroup.appendCell(new ConfigCellDivider());

--- a/TMessagesProj/src/main/kotlin/xyz/nextalone/nagram/NaConfig.kt
+++ b/TMessagesProj/src/main/kotlin/xyz/nextalone/nagram/NaConfig.kt
@@ -1395,6 +1395,12 @@ object NaConfig {
             ConfigItem.configTypeInt,
             1 // 0: off; 1: release; 2: beta
         )
+    val sendLockedCustomEmojiAsSticker =
+        addConfig(
+            "SendLockedCustomEmojiAsSticker",
+            ConfigItem.configTypeBool,
+            true
+        )
     val premiumItemEmojiStatus =
         addConfig(
             "PremiumItemEmojiStatus",

--- a/TMessagesProj/src/main/res/values/strings_nax.xml
+++ b/TMessagesProj/src/main/res/values/strings_nax.xml
@@ -254,6 +254,8 @@
     <string name="PreferCommonGroupsTab">Prefer Groups Tab</string>
     <string name="PreferCommonGroupsTabNotice">Auto-select \"Groups\" tab instead of \"Gifts\" when possible.</string>
     <string name="SendHighQualityPhoto">Send High Quality Photo</string>
+    <string name="SendLockedCustomEmojiAsSticker">Send Premium Emoji as Sticker</string>
+    <string name="SendLockedCustomEmojiAsStickerInfo">Only supports WebP/WebM custom emoji. TGS-only emoji are excluded.</string>
     <string name="GroupedMessageMenu">Group Message Menu</string>
     <string name="GroupedMessageMenuNotice">Grouping moves the main actions to the bottom of the message menu.</string>
     <string name="CopySticker">Copy Sticker</string>


### PR DESCRIPTION
# Send Premium Emoji as Sticker

Allows non-premium users to send premium custom emoji as normal stickers. Works by downloading the emoji file and re-uploading it as a sticker document. Only WebP and WebM custom emoji are supported, animated TGS emoji packs are excluded because Telegram no longer allows sending TGS files as stickers without an associated sticker pack.

### Settings

Toggle: **Experimental settings → "Send Premium Emoji as Sticker"** (default: enabled)

### Key changes

- Extended `EmojiViewDelegate` with `allowNonPremiumCustomEmoji`, `canShowNonPremiumCustomEmoji`, `onNonPremiumCustomEmojiSelected`
- Added `enabledForNonPremium` flag to `EmojiPack` for filtered display across grid, tabs, search, and pack headers
- New `sendCustomEmojiAsUploadedSticker` in `ChatActivityEnterView` with async file download queue
- Removed lock indicators from installed/featured emoji pack management screens
- Updated unlock logic in `EmojiPacksAlert` message info popup