### PR TITLE
Fix dialogs title overlap when opening or reloading chats

### DIFF
--- a/TMessagesProj/src/main/java/org/telegram/ui/DialogsActivity.java
+++ b/TMessagesProj/src/main/java/org/telegram/ui/DialogsActivity.java
@@ -1673,10 +1673,7 @@ public class DialogsActivity extends BaseFragment implements NotificationCenter.
             actionBar.getAdditionalSubTitleOverlayContainer().setScaleX(s);
 
             final float titleAlpha = containersAlpha * (1f - progressToActionMode);
-            actionBar.getTitlesContainer().setAlpha(titleAlpha);
-            actionBar.getTitlesContainer().setVisibility(titleAlpha > 0 ? View.VISIBLE : View.INVISIBLE);
-            actionBar.getAdditionalSubTitleOverlayContainer().setAlpha(titleAlpha);
-            actionBar.getAdditionalSubTitleOverlayContainer().setVisibility(titleAlpha > 0 ? View.VISIBLE : View.INVISIBLE);
+            updateActionBarTitleAlpha(titleAlpha);
         } else {
             actionBar.getTitlesContainer().setScaleY(1f);
             actionBar.getTitlesContainer().setScaleX(1f);
@@ -1686,11 +1683,19 @@ public class DialogsActivity extends BaseFragment implements NotificationCenter.
             actionBar.getAdditionalSubTitleOverlayContainer().setScaleX(1f);
 
             final float titleAlpha = 1f - progressToActionMode;
-            actionBar.getTitlesContainer().setAlpha(titleAlpha);
-            actionBar.getTitlesContainer().setVisibility(titleAlpha > 0 ? View.VISIBLE : View.INVISIBLE);
-            actionBar.getAdditionalSubTitleOverlayContainer().setAlpha(titleAlpha);
-            actionBar.getAdditionalSubTitleOverlayContainer().setVisibility(titleAlpha > 0 ? View.VISIBLE : View.INVISIBLE);
+            updateActionBarTitleAlpha(titleAlpha);
         }
+    }
+
+    private float lastActionBarTitleAlpha = 1f;
+
+    private void updateActionBarTitleAlpha(float titleAlpha) {
+        lastActionBarTitleAlpha = titleAlpha;
+        titleAlpha *= 1f - getRightSlidingProgress();
+        actionBar.getTitlesContainer().setAlpha(titleAlpha);
+        actionBar.getTitlesContainer().setVisibility(titleAlpha > 0 ? View.VISIBLE : View.INVISIBLE);
+        actionBar.getAdditionalSubTitleOverlayContainer().setAlpha(titleAlpha);
+        actionBar.getAdditionalSubTitleOverlayContainer().setVisibility(titleAlpha > 0 ? View.VISIBLE : View.INVISIBLE);
     }
 
     public static float viewOffset = 0.0f;
@@ -5692,6 +5697,11 @@ public class DialogsActivity extends BaseFragment implements NotificationCenter.
                 }
                 if (fragmentView != null) {
                     fragmentView.invalidate();
+                }
+
+                updateActionBarTitleAlpha(lastActionBarTitleAlpha);
+                if (dialogStoriesCell != null) {
+                    dialogStoriesCell.setRightSlidingProgress(progress);
                 }
 
                 if (actionBar.getTitleTextView() != null) {

--- a/TMessagesProj/src/main/java/org/telegram/ui/Stories/DialogStoriesCell.java
+++ b/TMessagesProj/src/main/java/org/telegram/ui/Stories/DialogStoriesCell.java
@@ -579,9 +579,19 @@ public class DialogStoriesCell extends FrameLayout implements NotificationCenter
     private float overScrollCoef = 1f;
     private float collapsedSpringCoef = 0.95f;
     private float expandedSpringCoef = 0.9f;
+    private float rightSlidingProgress;
 
     public float getOverScrollCoef() {
         return overScrollCoef;
+    }
+
+    public void setRightSlidingProgress(float progress) {
+        progress = MathUtils.clamp(progress, 0f, 1f);
+        if (rightSlidingProgress == progress) {
+            return;
+        }
+        rightSlidingProgress = progress;
+        checkUi_titleVisibility();
     }
 
     public void updateItems(boolean animated, boolean force) {
@@ -2213,10 +2223,11 @@ public class DialogStoriesCell extends FrameLayout implements NotificationCenter
 
     private void checkUi_titleVisibility() {
         final float progress = MathUtils.clamp(Math.min(collapsedProgress, collapsedProgress2), 0, 1);
+        final float rightSlidingFactor = 1f - rightSlidingProgress;
         final float titleVisibility = animatorHasTitleText.getFloatValue();
         final float logoVisibility = 1f - titleVisibility;
-        final float titleAlpha = titleVisibility * progress;
-        final float logoAlpha = logoVisibility * progress;
+        final float titleAlpha = titleVisibility * progress * rightSlidingFactor;
+        final float logoAlpha = logoVisibility * progress * rightSlidingFactor;
 
         if (titleView != null) {
             titleView.setAlpha(titleAlpha);
@@ -2231,8 +2242,9 @@ public class DialogStoriesCell extends FrameLayout implements NotificationCenter
             emojiStatusView.setVisibility(logoAlpha > 0 ? VISIBLE : GONE);
         }
         if (subtitleOverlayContainer != null) {
-            subtitleOverlayContainer.setAlpha(progress);
-            subtitleOverlayContainer.setVisibility(progress > 0 ? VISIBLE : GONE);
+            final float subtitleAlpha = progress * rightSlidingFactor;
+            subtitleOverlayContainer.setAlpha(subtitleAlpha);
+            subtitleOverlayContainer.setVisibility(subtitleAlpha > 0 ? VISIBLE : GONE);
         }
     }
 }


### PR DESCRIPTION
The dialogs screen can remain behind the opened chat/topic because chats/topics are opened in an overlay-style container instead of fully replacing the dialogs screen. during app startup, background resume, or network reloads, the dialogs screen title can be recalculated while a chat/topic is being opened or is already open. Before this change, those background title views were not tied to the opened chat/topic progress, so the dialogs title could become visible again and overlap the title of the opened chat/topic.

https://github.com/user-attachments/assets/37b1242c-8052-48f4-8a33-9f213e6324eb

## Testing
- Ran `:TMessagesProj:compileDebugJavaWithJavac`
- Ran `:TMessagesProj:assembleDebug`
- Tested on Samsung Galaxy S26

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the way chat list and story header titles fade and hide during right-side swipe interactions.
  * Kept title, subtitle, and logo visibility in sync while sliding, reducing flicker and inconsistent opacity.
  * Updated the related story panel to respond smoothly to swipe progress for a more polished UI.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->