### PR TITLE
fix: prevent crash when rendering translated rich messages

### DIFF
--- a/TMessagesProj/build.gradle
+++ b/TMessagesProj/build.gradle
@@ -406,6 +406,7 @@ dependencies {
     }
     implementation 'com.android.billingclient:billing:7.1.1'
     coreLibraryDesugaring 'com.android.tools:desugar_jdk_libs_nio:2.1.5'
+    testImplementation 'junit:junit:4.13.2'
 
     // kotlin
     implementation 'org.jetbrains.kotlinx:kotlinx-coroutines-android:1.10.2'

--- a/TMessagesProj/src/main/java/org/telegram/messenger/MediaDataController.java
+++ b/TMessagesProj/src/main/java/org/telegram/messenger/MediaDataController.java
@@ -7188,6 +7188,9 @@ public class MediaDataController extends BaseController {
 
     public static ArrayList<TextStyleSpan.TextStyleRun> getTextStyleRuns(ArrayList<TLRPC.MessageEntity> entities, CharSequence text, int allowedFlags) {
         ArrayList<TextStyleSpan.TextStyleRun> runs = new ArrayList<>();
+        if (entities == null || entities.isEmpty()) {
+            return runs;
+        }
         ArrayList<TLRPC.MessageEntity> entitiesCopy = new ArrayList<>(entities);
 
         Collections.sort(entitiesCopy, (o1, o2) -> {

--- a/TMessagesProj/src/main/java/tw/nekomimi/nekogram/helpers/MessageHelper.java
+++ b/TMessagesProj/src/main/java/tw/nekomimi/nekogram/helpers/MessageHelper.java
@@ -1133,7 +1133,10 @@ public class MessageHelper extends BaseController {
             if (messageOwner.voiceTranscriptionOpen) {
                 return messageOwner.translatedVoiceTranscription != null ? messageOwner.translatedVoiceTranscription.entities : null;
             } else {
-                return messageOwner.translatedText != null ? mergeAppendTranslatedEntities(messageOwner.entities, messageOwner.translatedText, text) : null;
+                if (messageOwner.translatedText != null) {
+                    return mergeAppendTranslatedEntities(messageOwner.entities, messageOwner.translatedText, text);
+                }
+                return text != null && messageOwner.message != null && messageOwner.message.contentEquals(text) ? messageOwner.entities : null;
             }
         }
         if (messageOwner.translated && messageOwner.translatedText != null) {

--- a/TMessagesProj/src/test/java/tw/nekomimi/nekogram/helpers/TranslationEntityHandlingTest.java
+++ b/TMessagesProj/src/test/java/tw/nekomimi/nekogram/helpers/TranslationEntityHandlingTest.java
@@ -1,0 +1,82 @@
+package tw.nekomimi.nekogram.helpers;
+
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertTrue;
+
+import org.junit.Test;
+import org.telegram.messenger.MediaDataController;
+import org.telegram.messenger.MessageObject;
+import org.telegram.tgnet.TLRPC;
+import org.telegram.tgnet.tl.TL_iv;
+
+import java.util.ArrayList;
+
+public class TranslationEntityHandlingTest {
+
+    @Test
+    public void nullEntitiesProduceNoStyleRuns() {
+        assertTrue(MediaDataController.getTextStyleRuns(null, "message", -1).isEmpty());
+    }
+
+    @Test
+    public void translatedRichMessageWithNoEntitiesProducesNoStyleRuns() {
+        MessageObject messageObject = createTranslatedRichMessage("original", null);
+        ArrayList<TLRPC.MessageEntity> entities = MessageHelper.getEntitiesForText(
+            messageObject,
+            new StringBuilder("original"),
+            false
+        );
+
+        assertNull(entities);
+        assertTrue(MediaDataController.getTextStyleRuns(entities, "original", -1).isEmpty());
+    }
+
+    @Test
+    public void translatedRichMessageKeepsEntitiesForEquivalentOriginalText() {
+        ArrayList<TLRPC.MessageEntity> entities = new ArrayList<>();
+        TLRPC.TL_messageEntityBold bold = new TLRPC.TL_messageEntityBold();
+        bold.offset = 0;
+        bold.length = 8;
+        entities.add(bold);
+        MessageObject messageObject = createTranslatedRichMessage("original", entities);
+
+        assertSame(
+            entities,
+            MessageHelper.getEntitiesForText(messageObject, new StringBuilder("original"), false)
+        );
+    }
+
+    @Test
+    public void translatedRichMessageDoesNotReuseEntitiesForDifferentText() {
+        ArrayList<TLRPC.MessageEntity> entities = new ArrayList<>();
+        entities.add(new TLRPC.TL_messageEntityBold());
+        MessageObject messageObject = createTranslatedRichMessage("original", entities);
+
+        assertNull(MessageHelper.getEntitiesForText(messageObject, "different", false));
+    }
+
+    private static MessageObject createTranslatedRichMessage(
+        String originalText,
+        ArrayList<TLRPC.MessageEntity> entities
+    ) {
+        TLRPC.TL_message message = new TLRPC.TL_message();
+        message.message = originalText;
+        message.entities = entities;
+        message.translatedRichMessage = new TL_iv.RichMessage();
+
+        MessageObject messageObject = new MessageObject(
+            0,
+            message,
+            originalText,
+            null,
+            null,
+            false,
+            false,
+            false,
+            false
+        );
+        messageObject.translated = true;
+        return messageObject;
+    }
+}


### PR DESCRIPTION
## Summary

Prevent a main-thread crash that can occur after translating rich/article messages.

The change also preserves original message entities when a translated non-text payload is shown through a preview that still renders the original text.

## Root cause

Rich-message translation stores translated content in `translatedRichMessage` while `translatedText` remains null. Once the translation is applied, `MessageObject.translated` can become true.

The entity lookup then enters the translated path and returns a null entity list. Pinned-message, reply, or dialog preview rendering can pass that null list to `MediaDataController.getTextStyleRuns()`, which previously constructed an `ArrayList` directly from the nullable collection and crashed on the main thread.

```text
java.lang.NullPointerException
    at java.util.ArrayList.<init>(ArrayList.java:188)
    at org.telegram.messenger.MediaDataController.getTextStyleRuns(...)
    at org.telegram.messenger.MediaDataController.addTextStyleRuns(...)
    at org.telegram.ui.ChatActivity.updatePinnedMessageView(...)
    at org.telegram.ui.ChatActivity.updateMessageTranslation(...)
```

## Fix

- Treat null or empty entity collections as producing no text-style runs.
- When a translated message has no `translatedText`, reuse its original entities only if the rendered text content exactly matches `messageOwner.message`. This preserves formatting for rich/poll preview text without applying offsets to unrelated text.
- Add regression tests covering null entities, translated rich messages without entities, equivalent preview `CharSequence` instances, and mismatched preview text.

The normal translated-text merge path and the dedicated voice/summary entity paths are unchanged.

## Reproduction

1. Enable chat translation.
2. Open a chat containing a translatable rich/article message.
3. Allow the rich-message translation to complete.
4. A message or pinned-message UI refresh reaches style-run generation with a null entity collection.
5. The app crashes on the main thread.

## Testing

- GitHub Actions `Unit test and compile` job passed with JDK 21 and Android SDK 36: https://github.com/sampple-korea/NagramXF/actions/runs/32738946226/job/97468468374
- Regression tests cover null entities, translated rich messages without entities, equivalent preview text, and mismatched preview text.
- `git diff --check` passed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved message formatting when translations are unavailable or translated text matches the original message.
  - Prevented processing issues when messages contain no formatting entities.
  - Ensured formatting is not incorrectly reused when message text differs.
  - Preserved original message formatting when voice transcription is closed and the text is unchanged.

- **Tests**
  - Added coverage for missing formatting data, translated messages, matching text, and differing text scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->